### PR TITLE
feat: support disabled state on BigButton

### DIFF
--- a/components/BigButton.js
+++ b/components/BigButton.js
@@ -3,16 +3,28 @@ import { Text, Pressable, StyleSheet, View } from 'react-native';
 // Se for usar ícones do Expo:
 // import { MaterialCommunityIcons } from '@expo/vector-icons';
 
-const BigButton = ({ title, onPress, buttonStyle, textStyle, iconName, iconFamily, iconSize = 22, iconColor = 'white' }) => {
+const BigButton = ({
+  title,
+  onPress,
+  buttonStyle,
+  textStyle,
+  iconName,
+  iconFamily,
+  iconSize = 22,
+  iconColor = 'white',
+  disabled = false,
+}) => {
   // const IconComponent = iconFamily; // Ex: MaterialCommunityIcons
 
   return (
     <Pressable
       onPress={onPress}
+      disabled={disabled}
       style={({ pressed }) => [
         styles.button,
         buttonStyle,
-        pressed && styles.buttonPressed,
+        disabled && styles.buttonDisabled,
+        pressed && !disabled && styles.buttonPressed,
       ]}
     >
       {/* {IconComponent && iconName && (
@@ -43,6 +55,9 @@ const styles = StyleSheet.create({
   buttonPressed: {
     opacity: 0.8,
     transform: [{ scale: 0.98 }]
+  },
+  buttonDisabled: {
+    opacity: 0.5,
   },
   icon: {
     marginRight: 10,

--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -96,7 +96,7 @@ export default function VideoUploadSender({
         title={statusText}
         onPress={handleProcessRequest}
         disabled={isUploading}
-        buttonStyle={[styles.actionButton, isUploading && styles.actionButtonDisabled]}
+        buttonStyle={styles.actionButton}
       />
       {isUploading && (
         <View style={styles.progressWrapper}>
@@ -110,7 +110,6 @@ export default function VideoUploadSender({
 const styles = StyleSheet.create({
   container: { marginTop: 20, width: '100%', alignItems: 'center' },
   actionButton: { backgroundColor: '#28a745', width: '100%' },
-  actionButtonDisabled: { backgroundColor: '#a5d6a7' },
   progressWrapper: { width: '100%', marginTop: 10 },
   progressBarContainer: { height: 10, width: '100%', backgroundColor: '#e0e0e0', borderRadius: 5, overflow: 'hidden' },
   progressBarFill: { height: '100%', backgroundColor: '#007AFF' },


### PR DESCRIPTION
## Summary
- allow BigButton to receive a disabled prop and dim its appearance
- simplify VideoUploadSender by relying on BigButton's disabled styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab3853cbf08321b3ea98da0cf00a5c