### PR TITLE
Use ApiContext for API base URL

### DIFF
--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -3,8 +3,7 @@ import { View, Text, Alert, StyleSheet } from 'react-native';
 import axios from 'axios';
 import BigButton from './BigButton';
 import CustomActivityIndicator from './CustomActivityIndicator';
-
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+import { useApi } from '../context/ApiContext';
 
 const InternalProgressBar = ({ progress }) => (
   <View style={styles.progressBarContainer}>
@@ -17,6 +16,7 @@ export default function VideoUploadSender({
   onProcessingStarted,
   onUploadError,
 }) {
+  const { apiUrl } = useApi();
   const [isUploading, setIsUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [statusText, setStatusText] = useState("Processar Vídeo");
@@ -26,7 +26,7 @@ export default function VideoUploadSender({
       Alert.alert('Faltam Dados', 'Por favor, selecione um vídeo, a orientação e o nível de processamento.');
       return;
     }
-    if (!API_BASE_URL) {
+    if (!apiUrl) {
       Alert.alert('Erro de Configuração', 'A URL da API não foi encontrada.');
       return;
     }
@@ -50,7 +50,7 @@ export default function VideoUploadSender({
     setStatusText("Enviando... 0%");
 
     try {
-      const response = await axios.post(`${API_BASE_URL}/process-video/`, formData, {
+      const response = await axios.post(`${apiUrl}/process-video/`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
         onUploadProgress: (progressEvent) => {
           // --- LOGS DE DEPURAÇÃO ADICIONADOS AQUI ---

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -13,8 +13,7 @@ import BigButton from '../components/BigButton';
 import VideoUploadSender from '../components/VideoUploadSender';
 import CustomActivityIndicator from '../components/CustomActivityIndicator';
 import MenuButton from '../components/MenuButton';
-
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+import { useApi } from '../context/ApiContext';
 
 const BackendProgressBar = ({ progress, text }) => (
   <View style={styles.backendProgressContainer}>
@@ -55,6 +54,7 @@ const MODEL_OPTIONS = [
 
 const HomeScreen = ({ route }) => {
   const navigation = useNavigation();
+  const { apiUrl } = useApi();
   const [selectedVideoAsset, setSelectedVideoAsset] = useState(null);
   const [isPickerLoading, setIsPickerLoading] = useState(false);
   const [appStatus, setAppStatus] = useState('idle');
@@ -141,7 +141,7 @@ const HomeScreen = ({ route }) => {
       return;
     }
     try {
-      const response = await axios.get(`${API_BASE_URL}/progresso/${videoName}`);
+      const response = await axios.get(`${apiUrl}/progresso/${videoName}`);
       const progressData = response.data;
       setBackendProgressData(progressData);
       if (progressData.finalizado) {
@@ -172,7 +172,7 @@ const HomeScreen = ({ route }) => {
   const handleCancelProcessing = async () => {
     if (processingVideoName) {
       try {
-        await axios.get(`${API_BASE_URL}/cancelar-processamento/${processingVideoName}`);
+        await axios.get(`${apiUrl}/cancelar-processamento/${processingVideoName}`);
         Alert.alert('Cancelado', 'Solicitação de cancelamento da análise enviada.');
       } catch (error) { Alert.alert('Erro', 'Não foi possível enviar solicitação de cancelamento.'); }
       finally { resetAllStates(); }

--- a/utils/sendVideo.js
+++ b/utils/sendVideo.js
@@ -1,9 +1,9 @@
 import * as DocumentPicker from 'expo-document-picker';
 import axios from 'axios';
+import { useApi } from '../context/ApiContext';
 
-
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 export async function pickAndUploadVideo() {
+  const { apiUrl } = useApi();
   try {
     const result = await DocumentPicker.getDocumentAsync({
       type: 'video/*',
@@ -20,7 +20,7 @@ export async function pickAndUploadVideo() {
       type: 'video/mp4',
     });
 
-    const response = await axios.post(API_BASE_URL, formData, {
+    const response = await axios.post(apiUrl, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
 


### PR DESCRIPTION
## Summary
- use ApiContext hook to retrieve API URL on home screen, video upload sender, and sendVideo util
- replace direct env usage with context-driven `apiUrl`

## Testing
- `npm test` *(fails: To see a list of scripts, run: npm run)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ab39b11bf88321a9578932f02572ab