### PR TITLE
Configura ambiente para backend local

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,8 @@
 # Prefixe suas variáveis com EXPO_PUBLIC_ para que o Expo as torne acessíveis no seu app.
 # Para desenvolvimento local, use seu IP local:
-#EXPO_PUBLIC_API_URL="http://192.168.0.48:8000"
+#URL do backend local para testes
+EXPO_PUBLIC_API_URL="http://192.168.0.48:8000"
 
 # Quando for fazer o build para produção, você pode trocar para a URL do Render:
 #EXPO_PUBLIC_API_URL="https://countg.onrender.com"
-EXPO_PUBLIC_API_URL="https://pedrorezp3-countg.hf.space"
+#EXPO_PUBLIC_API_URL="https://pedrorezp3-countg.hf.space"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ CountGFront is the mobile interface for the CountG project. Built with React Nat
    cd CountGFront
    npm install
    ```
+   Configure o arquivo `.env` para apontar para o backend local:
+   ```bash
+   EXPO_PUBLIC_API_URL="http://<seu-ip-local>:8000"
+   ```
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- define EXPO_PUBLIC_API_URL para servidor local
- documenta no README como apontar para o backend local

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc3125fc64832187749d0d0c92a1d7