### PR TITLE
Use upload-video endpoint

### DIFF
--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -66,7 +66,7 @@ export default function VideoUploadSender({
     setStatusText('Uploading... 0%');
 
     try {
-      const response = await axios.post(`${apiUrl}/process-video/`, formData, {
+      const response = await axios.post(`${apiUrl}/upload-video/`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
         onUploadProgress: (progressEvent) => {
           // --- DEBUG LOGS ADDED HERE ---

--- a/utils/sendVideo.js
+++ b/utils/sendVideo.js
@@ -20,7 +20,7 @@ export async function pickAndUploadVideo() {
       type: 'video/mp4',
     });
 
-    const response = await axios.post(apiUrl, formData, {
+    const response = await axios.post(`${apiUrl}/upload-video/`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
 


### PR DESCRIPTION
## Summary
- point upload requests to `/upload-video/`
- align sendVideo util with new endpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e3333508321844ae077bb623559