### PR TITLE
Send predict request after video upload

### DIFF
--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -96,17 +96,22 @@ export default function VideoUploadSender({
         timeout: 600000,
       });
 
-      // When upload finishes, update status before calling the callback
-      setStatusText('Upload complete. Waiting for processing to start...');
+      // When upload finishes, initiate prediction
+      setStatusText('Upload complete. Starting analysis...');
+
+      const predictResponse = await axios.post(
+        `${apiUrl}/predict-video/`,
+        { nome_arquivo: response.data?.nome_arquivo }
+      );
 
       if (onProcessingStarted) {
-        onProcessingStarted(response.data);
+        onProcessingStarted(predictResponse.data);
       }
     } catch (error) {
       const errorMsg =
         error.response?.data?.detail ||
-        'Failed to upload video for processing.';
-      Alert.alert('Upload Error', errorMsg);
+        'Failed to start video processing.';
+      Alert.alert('Processing Error', errorMsg);
       if (onUploadError) onUploadError(error);
     } finally {
       setIsUploading(false);

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -180,8 +180,9 @@ const HomeScreen = ({ route }) => {
   };
 
   const handleProcessingStarted = (responseData) => {
-    if (responseData && responseData.video_name) {
-      setProcessingVideoName(responseData.video_name);
+    const videoName = responseData?.video_name || responseData?.nome_arquivo;
+    if (videoName) {
+      setProcessingVideoName(videoName);
       setAppStatus('polling_progress');
     } else {
       Alert.alert('Error', 'The server did not start processing correctly.');


### PR DESCRIPTION
## Summary
- start analysis by POSTing to `/predict-video/` after `/upload-video/`
- use predict response in `onProcessingStarted` to trigger polling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bda21c477c8321ab14322f1d8b9042