### PR TITLE
feat: add video editor dependency

### DIFF
--- a/app.json
+++ b/app.json
@@ -60,7 +60,8 @@
           "recordAudioAndroid": true
         }
       ],
-      "expo-font"
+      "expo-font",
+      "@imgly/editor-react-native"
     ],
     "assetBundlePatterns": ["assets/images/*", "assets/fonts/*"],
     "extra": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@expo/vector-icons": "^14.0.0",
+        "@imgly/editor-react-native": "^1.59.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/native": "^7.0.0",
         "@react-navigation/native-stack": "^7.0.0",
@@ -2020,6 +2021,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@imgly/editor-react-native": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@imgly/editor-react-native/-/editor-react-native-1.59.0.tgz",
+      "integrity": "sha512-orZgXPKWBV4RRKKlaBI2pdizve8y0PtYUa41ASp/xKhK18WxB0YSClBXKiHXMLKWe0EsduEbMk/+gXJeix4aJg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
+    "@imgly/editor-react-native": "^1.59.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/native": "^7.0.0",
     "@react-navigation/native-stack": "^7.0.0",


### PR DESCRIPTION
## Summary
- add @imgly/editor-react-native for trimming support
- configure app.json with @imgly/editor-react-native plugin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx expo install @imgly/editor-react-native` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68beb89206948321b9944dda575bfbaf