### PR TITLE
Route recorded video through editor

### DIFF
--- a/screens/RecordVideoScreen.js
+++ b/screens/RecordVideoScreen.js
@@ -144,7 +144,7 @@ export default function RecordVideoScreen({ navigation }) {
         orientation: currentOrientation.id, // <<< ENVIA A ORIENTAÇÃO SELECIONADA
       };
 
-      navigation.replace('Home', { newlyRecordedVideo: recordedVideoAsset });
+      navigation.replace('VideoEditor', { asset: recordedVideoAsset });
     } catch (error) {
       if (
         error.message.includes(

--- a/screens/VideoEditorScreen.js
+++ b/screens/VideoEditorScreen.js
@@ -23,8 +23,11 @@ export default function VideoEditorScreen({ route, navigation }) {
         const trimmedAsset = {
           uri: result.uri,
           duration: result.duration,
+          fileName: asset?.fileName || result.uri.split('/').pop(),
+          mimeType: asset?.mimeType || 'video/mp4',
+          orientation: asset?.orientation,
         };
-        navigation.navigate('Home', { trimmedVideo: trimmedAsset });
+        navigation.replace('Home', { newlyRecordedVideo: trimmedAsset });
       }
     } catch (error) {
       console.warn('Video trimming failed', error);


### PR DESCRIPTION
## Summary
- send freshly recorded video to the editor instead of Home
- return trimmed video with preserved orientation back to Home

## Testing
- `npm run format`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bedcc0b9b483218b5a40791388eeb8