### PR TITLE
Route gallery videos through editor

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -106,17 +106,22 @@ const HomeScreen = ({ route }) => {
 
   useFocusEffect(
     React.useCallback(() => {
-      if (route.params?.newlyRecordedVideo) {
-        const video = route.params.newlyRecordedVideo;
+      const { trimmedVideo, newlyRecordedVideo } = route.params || {};
+      const video = trimmedVideo || newlyRecordedVideo;
+      if (video) {
         resetAllStates();
         setSelectedVideoAsset(video);
         if (video.orientation) {
           setSelectedOrientation(video.orientation);
         }
         setAppStatus('selected');
-        navigation.setParams({ newlyRecordedVideo: null });
+        navigation.setParams({ trimmedVideo: null, newlyRecordedVideo: null });
       }
-    }, [route.params?.newlyRecordedVideo, navigation])
+    }, [
+      route.params?.trimmedVideo,
+      route.params?.newlyRecordedVideo,
+      navigation,
+    ])
   );
 
   useEffect(() => {
@@ -167,8 +172,7 @@ const HomeScreen = ({ route }) => {
         quality: 0.8,
       });
       if (!result.canceled && result.assets && result.assets.length > 0) {
-        setSelectedVideoAsset(result.assets[0]);
-        setAppStatus('selected');
+        navigation.navigate('VideoEditor', { asset: result.assets[0] });
       } else {
         resetAllStates();
       }

--- a/screens/VideoEditorScreen.js
+++ b/screens/VideoEditorScreen.js
@@ -27,7 +27,7 @@ export default function VideoEditorScreen({ route, navigation }) {
           mimeType: asset?.mimeType || 'video/mp4',
           orientation: asset?.orientation,
         };
-        navigation.replace('Home', { newlyRecordedVideo: trimmedAsset });
+        navigation.navigate('Home', { trimmedVideo: trimmedAsset });
       }
     } catch (error) {
       console.warn('Video trimming failed', error);


### PR DESCRIPTION
## Summary
- Send gallery selection to the VideoEditor screen and expect trimmed video return
- Prioritize `trimmedVideo` route param on focus
- Return trimmed asset from VideoEditor back to Home

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bee7e305ac8321b2ecef2007a402bf