### PR TITLE
chore: remove imgly editor

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,10 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "permissions": ["READ_EXTERNAL_STORAGE", "WRITE_EXTERNAL_STORAGE"],
+      "permissions": [
+        "READ_EXTERNAL_STORAGE",
+        "WRITE_EXTERNAL_STORAGE"
+      ],
       "versionCode": 2,
       "package": "com.rezendepedro.CounG"
     },
@@ -60,10 +63,12 @@
           "recordAudioAndroid": true
         }
       ],
-      "expo-font",
-      "@imgly/editor-react-native"
+      "expo-font"
     ],
-    "assetBundlePatterns": ["assets/images/*", "assets/fonts/*"],
+    "assetBundlePatterns": [
+      "assets/images/*",
+      "assets/fonts/*"
+    ],
     "extra": {
       "eas": {
         "projectId": "a46adc85-0390-4ed7-a306-abd542a28655"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@expo/vector-icons": "^14.0.0",
-        "@imgly/editor-react-native": "^1.59.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-navigation/native": "^7.0.0",
         "@react-navigation/native-stack": "^7.0.0",
@@ -2021,16 +2020,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@imgly/editor-react-native": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@imgly/editor-react-native/-/editor-react-native-1.59.0.tgz",
-      "integrity": "sha512-orZgXPKWBV4RRKKlaBI2pdizve8y0PtYUa41ASp/xKhK18WxB0YSClBXKiHXMLKWe0EsduEbMk/+gXJeix4aJg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
-    "@imgly/editor-react-native": "^1.59.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/native": "^7.0.0",
     "@react-navigation/native-stack": "^7.0.0",


### PR DESCRIPTION
## Summary
- remove unused @imgly/editor-react-native dependency and plugin

## Testing
- `npm install`
- `npm test` (fails: Missing script: "test")
- `npx expo start --offline`

------
https://chatgpt.com/codex/tasks/task_e_68bef95ab144832191861ed54f8f8dc7