### PR TITLE
Add expo-video-editor dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-native": "0.79.3",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.11.1"
+    "react-native-screens": "~4.11.1",
+    "expo-video-editor": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add `expo-video-editor` to dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: Not Found - expo-video-editor@latest)*
- `npx expo start -c` *(cache cleared, Metro Bundler started)*

------
https://chatgpt.com/codex/tasks/task_e_68bf034b1ee48321a2b5703b48c55857