### PR TITLE
Remove unused fields from video upload

### DIFF
--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -17,8 +17,6 @@ const InternalProgressBar = ({ progress }) => (
 
 export default function VideoUploadSender({
   videoAsset,
-  email,
-  consent,
   orientation,
   modelChoice,
   onProcessingStarted,
@@ -63,14 +61,6 @@ export default function VideoUploadSender({
       name: fileName,
       type: mimeType,
     });
-    formData.append('orientation', finalOrientation);
-    formData.append('model_choice', modelChoice);
-    if (email && email.trim() !== '') {
-      formData.append('email', email.trim());
-    }
-    if (consent) {
-      formData.append('consent', String(consent));
-    }
 
     setIsUploading(true);
     setUploadProgress(0);


### PR DESCRIPTION
## Summary
- send only video file in upload request
- drop unused email and consent props

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f7e151883218aa97ce9882054ec