### PR TITLE
Fetch orientation options dynamically

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,7 +5,8 @@ import { View, StyleSheet, Alert, AppState } from 'react-native';
 import axios from 'axios';
 import AppNavigator from './navigation/AppNavigator';
 import CustomActivityIndicator from './components/CustomActivityIndicator';
-import { ApiProvider, useApi } from './context/ApiContext'; // Import our provider and hook
+import { ApiProvider, useApi } from './context/ApiContext';
+import { OrientationMapProvider } from './context/OrientationMapContext';
 
 const APP_LAUNCHED_KEY = 'appAlreadyLaunched';
 
@@ -102,7 +103,9 @@ const AppContent = () => {
 export default function App() {
   return (
     <ApiProvider>
-      <AppContent />
+      <OrientationMapProvider>
+        <AppContent />
+      </OrientationMapProvider>
     </ApiProvider>
   );
 }

--- a/context/OrientationMapContext.js
+++ b/context/OrientationMapContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import axios from 'axios';
+import { useApi } from './ApiContext';
+
+const OrientationMapContext = createContext();
+
+export const OrientationMapProvider = ({ children }) => {
+  const { apiUrl } = useApi();
+  const [orientationMap, setOrientationMap] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchOrientationMap = useCallback(async () => {
+    if (orientationMap || isLoading) return;
+    setIsLoading(true);
+    try {
+      const response = await axios.get(`${apiUrl}/orientation-map`);
+      setOrientationMap(response.data);
+    } catch (error) {
+      console.error('Failed to load orientation map:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiUrl, orientationMap, isLoading]);
+
+  return (
+    <OrientationMapContext.Provider
+      value={{ orientationMap, fetchOrientationMap, isLoading }}
+    >
+      {children}
+    </OrientationMapContext.Provider>
+  );
+};
+
+export const useOrientationMap = () => useContext(OrientationMapContext);

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -22,6 +22,7 @@ import VideoUploadSender from '../components/VideoUploadSender';
 import CustomActivityIndicator from '../components/CustomActivityIndicator';
 import MenuButton from '../components/MenuButton';
 import { useApi } from '../context/ApiContext';
+import { useOrientationMap } from '../context/OrientationMapContext';
 
 const { MediaTypeOptions } = ImagePicker;
 
@@ -58,13 +59,6 @@ const formatDuration = (millis) => {
   return str;
 };
 
-const ORIENTATIONS = [
-  { id: 'N', label: 'Bottom ↑ Top' },
-  { id: 'S', label: 'Top ↓ Bottom' },
-  { id: 'E', label: 'Left → Right' },
-  { id: 'W', label: 'Right ← Left' },
-];
-
 const MODEL_OPTIONS = [
   { id: 'n', label: 'Fast', description: 'Lower accuracy' },
   { id: 'm', label: 'Normal', description: 'Balanced' },
@@ -74,6 +68,7 @@ const MODEL_OPTIONS = [
 const HomeScreen = ({ route }) => {
   const navigation = useNavigation();
   const { apiUrl } = useApi();
+  const { orientationMap, fetchOrientationMap } = useOrientationMap();
   const [selectedVideoAsset, setSelectedVideoAsset] = useState(null);
   const [isPickerLoading, setIsPickerLoading] = useState(false);
   const [appStatus, setAppStatus] = useState('idle');
@@ -86,6 +81,10 @@ const HomeScreen = ({ route }) => {
 
   const pollingIntervalRef = useRef(null);
   const appStateListenerRef = useRef(AppState.currentState);
+
+  useEffect(() => {
+    fetchOrientationMap();
+  }, [fetchOrientationMap]);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -408,27 +407,33 @@ const HomeScreen = ({ route }) => {
             <View style={styles.choiceSection}>
               <Text style={styles.choiceTitle}>Movement Orientation</Text>
               <View style={styles.orientationButtonsContainer}>
-                {ORIENTATIONS.map((orient) => (
-                  <TouchableOpacity
-                    key={orient.id}
-                    style={[
-                      styles.orientationButton,
-                      selectedOrientation === orient.id &&
-                        styles.orientationButtonSelected,
-                    ]}
-                    onPress={() => setSelectedOrientation(orient.id)}
-                  >
-                    <Text
-                      style={[
-                        styles.orientationButtonText,
-                        selectedOrientation === orient.id &&
-                          styles.orientationButtonTextSelected,
-                      ]}
-                    >
-                      {orient.label}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
+                {orientationMap ? (
+                  Object.entries(orientationMap).map(
+                    ([id, { label, arrow }]) => (
+                      <TouchableOpacity
+                        key={id}
+                        style={[
+                          styles.orientationButton,
+                          selectedOrientation === id &&
+                            styles.orientationButtonSelected,
+                        ]}
+                        onPress={() => setSelectedOrientation(id)}
+                      >
+                        <Text
+                          style={[
+                            styles.orientationButtonText,
+                            selectedOrientation === id &&
+                              styles.orientationButtonTextSelected,
+                          ]}
+                        >
+                          {label} {arrow}
+                        </Text>
+                      </TouchableOpacity>
+                    )
+                  )
+                ) : (
+                  <CustomActivityIndicator size="small" color="#007AFF" />
+                )}
               </View>
             </View>
             <View style={styles.choiceSection}>


### PR DESCRIPTION
## Summary
- load `/orientation-map` once and share via new `OrientationMapContext`
- wrap app with orientation map provider
- use backend-supplied orientation labels and arrows on HomeScreen

## Testing
- `npx prettier context/OrientationMapContext.js App.js screens/HomeScreen.js -w`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f86ff7c83219ab461183556b8bc