### PR TITLE
Handle target classes selection in video prediction

### DIFF
--- a/components/VideoUploadSender.js
+++ b/components/VideoUploadSender.js
@@ -19,6 +19,7 @@ export default function VideoUploadSender({
   videoAsset,
   orientation,
   modelChoice,
+  targetClasses,
   onProcessingStarted,
   onUploadError,
 }) {
@@ -109,14 +110,21 @@ export default function VideoUploadSender({
 
       setStatusText('Upload complete. Starting analysis...');
 
-      const predictResponse = await axios.post(`${apiUrl}/predict-video/`, {
+      const predictPayload = {
         nome_arquivo: responseData?.nome_arquivo,
         orientation: finalOrientation,
         model_choice: modelChoice,
-        // TODO: Replace placeholder values with real data as needed
-        target_classes: [],
         line_position_ratio: ratioNum,
-      });
+        target_classes:
+          Array.isArray(targetClasses) && targetClasses.length > 0
+            ? targetClasses
+            : null,
+      };
+
+      const predictResponse = await axios.post(
+        `${apiUrl}/predict-video/`,
+        predictPayload
+      );
 
       if (onProcessingStarted) {
         onProcessingStarted(predictResponse.data);


### PR DESCRIPTION
## Summary
- Allow `VideoUploadSender` to accept optional target class list
- Send `target_classes` as `null` when no specific classes are chosen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf17cb54ac83219185991c18b16635