### PR TITLE
Add prop-types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "expo-media-library": "~17.1.7",
         "expo-modules-core": "~2.4.0",
         "expo-status-bar": "~2.2.3",
+        "prop-types": "^15.8.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.3",
@@ -8099,6 +8100,23 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-media-library": "~17.1.7",
     "expo-modules-core": "~2.4.0",
     "expo-status-bar": "~2.2.3",
+    "prop-types": "^15.8.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.3",


### PR DESCRIPTION
## Summary
- add `prop-types` package to project dependencies

## Testing
- `npm install`
- `npm test` (fails: Missing script)
- `npx expo start -c` (starts Metro Bundler then aborted)
- `npm run android` (began Android prebuild then aborted)


------
https://chatgpt.com/codex/tasks/task_e_68bf200786d883219d1530f74572fc3f