### PR TITLE
Ensure VideoPlayer resizeMode safe usage

### DIFF
--- a/screens/VideoEditorScreen.js
+++ b/screens/VideoEditorScreen.js
@@ -26,6 +26,9 @@ export default function VideoEditorScreen({ route, navigation }) {
     initialDuration > 1000 ? initialDuration / 1000 : initialDuration,
   );
 
+  const resizeMode =
+    VideoPlayer?.Constants?.resizeMode?.CONTAIN ?? 'contain';
+
   const handleCancel = () => {
     navigation.goBack();
   };
@@ -60,7 +63,7 @@ export default function VideoEditorScreen({ route, navigation }) {
         startTime={startTime}
         endTime={endTime}
         play={false}
-        resizeMode={VideoPlayer.Constants.resizeMode.CONTAIN}
+        resizeMode={resizeMode}
       />
 
       <Trimmer


### PR DESCRIPTION
## Summary
- Safely access `VideoPlayer.Constants.resizeMode` with optional chaining and fallback
- Use computed resize mode when rendering VideoPlayer

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf298d42bc8321807ebff6a5edef64