### PR TITLE
refactor: migrate video trimming to expo modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "expo-av": "~15.1.7",
-    "ffmpeg-kit-react-native": "^6.0.2"
+    "ffmpeg-kit-react-native": "^6.0.2",
+    "@react-native-community/slider": "^5.0.1",
+    "expo-video-manipulator": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- replace react-native-video-processing with Expo's `Video` and `VideoManipulator`
- add dual sliders for start/end times in video editor
- declare new dependencies for slider and video manipulation

## Testing
- `npx prettier --check screens/VideoEditorScreen.js package.json`
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: expo-video-manipulator not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf636de6348321b54e35d131f9a3c4