### PR TITLE
docs: clarify media dependencies and trimming roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,65 @@ CountGFront is the mobile interface for the CountG project. Built with React Nat
    EXPO_PUBLIC_API_URL="http://<seu-ip-local>:8000"
    ```
 
+## Media Dependencies
+
+The app manipulates audio and video and relies on a few extra packages:
+
+- [`expo-av`](https://docs.expo.dev/versions/latest/sdk/av/) for playback and
+  recording.
+- [`expo-video-manipulator`](https://docs.expo.dev/versions/latest/sdk/video-manipulator/)
+  for simple trimming in a fully managed workflow.
+- [`ffmpeg-kit-react-native`](https://github.com/arthenica/ffmpeg-kit)
+  when advanced processing is needed.
+
+Install the packages with Expo's helper, choosing either `expo-video-manipulator`
+or `ffmpeg-kit-react-native` depending on the desired workflow:
+
+```bash
+npx expo install expo-av
+
+# Expo managed workflow (lightweight)
+npx expo install expo-video-manipulator
+
+# Bare / prebuild workflow with full FFmpeg
+npm install ffmpeg-kit-react-native
+```
+
+Using `ffmpeg-kit-react-native` requires generating the native project with
+`npx expo prebuild` and building through `expo run:android` or `expo run:ios`.
+
+### Hermes
+
+Hermes is enabled by default in recent React Native versions. If build issues
+occur with `ffmpeg-kit-react-native`, disable Hermes by setting
+`"jsEngine": "jsc"` in `app.json` or by toggling `hermesEnabled=false` in
+`android/gradle.properties`.
+
+### ffmpeg-kit package size and build flags
+
+`ffmpeg-kit-react-native` ships in different variants that impact the final
+binary size:
+
+- `min` / `min-gpl` – smaller, with a reduced codec set.
+- `full` / `full-gpl` – include most codecs but can push the APK/IPA well above
+  typical store limits.
+
+Select a variant during the native build:
+
+```gradle
+// android/build.gradle
+ext.ffmpegKitPackage = "min-gpl"  // or "full-gpl"
+```
+
+```ruby
+# ios/Podfile
+pod 'ffmpeg-kit-react-native/full-gpl'
+```
+
+The `*-gpl` variants include GPL components and are built with the
+`--enable-gpl` flag. Other compile-time flags may be added following the
+[ffmpeg-kit documentation](https://github.com/arthenica/ffmpeg-kit#configure-ffmpeg).
+
 ## Usage
 
 1. Start the Expo server:
@@ -48,6 +107,23 @@ CountGFront is the mobile interface for the CountG project. Built with React Nat
 
 ![Camera positioning](assets/images/camera_positioning.png)
 ![Counting line setup](assets/images/counting_line.png)
+
+## Known Limitations and Future Improvements
+
+- The trimming screen is built on `react-native-video-processing` and provides
+  only a basic timeline. Frame-precise control and visual thumbnails are not yet
+  available.
+- The current UI may feel clunky for long videos and lacks accessibility
+  features.
+
+Future work:
+
+- Implement a custom dual-thumb slider for start/end selection with preview
+  thumbnails.
+- Integrate trimming directly with `ffmpeg-kit` or `expo-video-manipulator` for
+  better performance and cross-platform consistency.
+- Extend the editor to support additional operations such as rotation or
+  multiple segments.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
## Summary
- document expo-av, expo-video-manipulator and ffmpeg-kit dependencies with install steps and Hermes notes
- explain ffmpeg-kit package size/compile flags and suggest future trim features

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf637fdb248321be39f4de836e4869