### PR TITLE
Aprimora tela de gravação e metadados para evitar falhas de encoding

### DIFF
--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -19,6 +19,7 @@ import * as ImagePicker from 'expo-image-picker';
 import axios from 'axios';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library';
+import { resolveVideoMimeType } from '../utils/videoMime';
 
 import BigButton from '../components/BigButton';
 import VideoUploadSender from '../components/VideoUploadSender';
@@ -96,12 +97,11 @@ const buildSafeVideoAsset = (asset, fallbackName) => {
   if (!asset) return null;
   const uri = asset?.uri || asset?.localUri;
   if (!uri) return null;
-  const fileName =
-    asset?.fileName || fallbackName || uri.split('/').pop();
+  const fileName = asset?.fileName || fallbackName || uri.split('/').pop();
   return {
     uri,
     fileName,
-    mimeType: asset?.mimeType || 'video/mp4',
+    mimeType: resolveVideoMimeType(uri, asset?.mimeType || 'video/mp4'),
     duration: asset?.duration ?? 0,
     width: asset?.width,
     height: asset?.height,
@@ -114,7 +114,8 @@ const ensureLocalVideoUri = async (asset) => {
   if (!asset?.uri) return asset;
   if (!asset.uri.startsWith('content://')) return asset;
   try {
-    const fileName = asset.fileName || asset.uri.split('/').pop() || 'video.mp4';
+    const fileName =
+      asset.fileName || asset.uri.split('/').pop() || 'video.mp4';
     const safeName = fileName.includes('.') ? fileName : `${fileName}.mp4`;
     const targetUri = `${FileSystem.cacheDirectory}${Date.now()}_${safeName}`;
     await FileSystem.copyAsync({ from: asset.uri, to: targetUri });
@@ -231,7 +232,8 @@ const HomeScreen = ({ route }) => {
 
   useFocusEffect(
     React.useCallback(() => {
-      const { trimmedVideo, newlyRecordedVideo, resetHome } = route.params || {};
+      const { trimmedVideo, newlyRecordedVideo, resetHome } =
+        route.params || {};
       if (resetHome) {
         resetAllStates();
         navigation.setParams({ resetHome: null });
@@ -244,7 +246,10 @@ const HomeScreen = ({ route }) => {
         const enrichedVideo = {
           uri: rawVideo.uri,
           fileName: rawVideo.fileName || rawVideo.uri.split('/').pop(),
-          mimeType: rawVideo.mimeType || 'video/mp4',
+          mimeType: resolveVideoMimeType(
+            rawVideo.uri,
+            rawVideo.mimeType || 'video/mp4'
+          ),
           duration: rawVideo.duration ?? 0,
           originalDurationMs:
             rawVideo.originalDurationMs ??
@@ -950,9 +955,7 @@ const HomeScreen = ({ route }) => {
       case 'polling_progress':
         return (
           <View style={styles.processingContainerFull}>
-            <Text style={styles.statusTitle}>
-              {t('home.processing.title')}
-            </Text>
+            <Text style={styles.statusTitle}>{t('home.processing.title')}</Text>
             {renderProcessingContent()}
             <BigButton
               title={t('home.processing.cancel')}
@@ -961,23 +964,22 @@ const HomeScreen = ({ route }) => {
             />
           </View>
         );
-      case 'saving_result':
-        {
-          const safeDownloadProgress = Number.isFinite(downloadProgress)
-            ? downloadProgress
-            : 0;
-          return (
-            <View style={styles.processingContainerFull}>
-              <Text style={styles.statusTitle}>
-                {t('home.processing.downloadingTitle')}
-              </Text>
-              <BackendProgressBar
-                progress={safeDownloadProgress}
-                text={t('home.processing.downloading')}
-              />
-            </View>
-          );
-        }
+      case 'saving_result': {
+        const safeDownloadProgress = Number.isFinite(downloadProgress)
+          ? downloadProgress
+          : 0;
+        return (
+          <View style={styles.processingContainerFull}>
+            <Text style={styles.statusTitle}>
+              {t('home.processing.downloadingTitle')}
+            </Text>
+            <BackendProgressBar
+              progress={safeDownloadProgress}
+              text={t('home.processing.downloading')}
+            />
+          </View>
+        );
+      }
       default:
         return null;
     }

--- a/screens/RecordVideoScreen.js
+++ b/screens/RecordVideoScreen.js
@@ -14,6 +14,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import CustomActivityIndicator from '../components/CustomActivityIndicator';
 import { useLanguage } from '../context/LanguageContext';
 import { useCameraPermissions } from '../hooks/useCameraPermissions';
+import { resolveVideoMimeType } from '../utils/videoMime';
 
 // Function to format time
 const formatSecondsToMMSS = (totalSeconds) => {
@@ -135,13 +136,15 @@ export default function RecordVideoScreen({ navigation, route }) {
     startRecordingTimer();
 
     try {
-      const data = await cameraRef.current.recordAsync();
+      const data = await cameraRef.current.recordAsync({
+        maxDuration: 180,
+      });
 
       const currentOrientation = guideOrientations[guideOrientationIndex];
       const recordedVideoAsset = {
         uri: data.uri,
         fileName: data.uri.split('/').pop(),
-        mimeType: Platform.OS === 'ios' ? 'video/quicktime' : 'video/mp4',
+        mimeType: resolveVideoMimeType(data.uri),
         duration: elapsedTime * 1000,
         orientation: currentOrientation.id, // <<< ENVIA A ORIENTACAO SELECIONADA
       };
@@ -173,18 +176,14 @@ export default function RecordVideoScreen({ navigation, route }) {
     return (
       <View style={styles.centered}>
         <CustomActivityIndicator size="large" color="#FFF" />
-        <Text style={styles.infoText}>
-          {t('record.loadingPermissions')}
-        </Text>
+        <Text style={styles.infoText}>{t('record.loadingPermissions')}</Text>
       </View>
     );
   }
   if (hasPermission === false) {
     return (
       <SafeAreaView style={styles.centered}>
-        <Text style={styles.infoText}>
-          {t('record.permissionDenied')}
-        </Text>
+        <Text style={styles.infoText}>{t('record.permissionDenied')}</Text>
         <TouchableOpacity
           onPress={() => navigation.goBack()}
           style={styles.backButton}

--- a/screens/VideoEditorScreen.js
+++ b/screens/VideoEditorScreen.js
@@ -1,4 +1,10 @@
-import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+} from 'react';
 import {
   View,
   Text,
@@ -11,10 +17,14 @@ import {
 } from 'react-native';
 import { Video, ResizeMode } from 'expo-av';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
 import { useOrientationMap } from '../context/OrientationMapContext';
 import { useLanguage } from '../context/LanguageContext';
+import { resolveVideoMimeType } from '../utils/videoMime';
 
 const MIN_GAP_SECONDS = 0.1;
 const LINE_RATIO_STEP = 0.05;
@@ -151,8 +161,7 @@ export default function VideoEditorScreen({ route, navigation }) {
   const { orientationMap, fetchOrientationMap } = useOrientationMap();
   const { t } = useLanguage();
   const insets = useSafeAreaInsets();
-  const initialDuration =
-    asset?.originalDurationMs ?? asset?.duration ?? 0;
+  const initialDuration = asset?.originalDurationMs ?? asset?.duration ?? 0;
   const initialDurationSeconds =
     initialDuration > 1000 ? initialDuration / 1000 : initialDuration;
 
@@ -198,7 +207,9 @@ export default function VideoEditorScreen({ route, navigation }) {
     [orientationStyleMap]
   );
 
-  const [durationSeconds, setDurationSeconds] = useState(initialDurationSeconds);
+  const [durationSeconds, setDurationSeconds] = useState(
+    initialDurationSeconds
+  );
   const [startTime, setStartTime] = useState(safeInitialStart);
   const [endTime, setEndTime] = useState(safeInitialEnd);
   const [currentTime, setCurrentTime] = useState(0);
@@ -372,9 +383,7 @@ export default function VideoEditorScreen({ route, navigation }) {
       (option) => option.id === selectedOrientationId
     );
     const nextIndex =
-      currentIndex >= 0
-        ? (currentIndex + 1) % orientationOptions.length
-        : 0;
+      currentIndex >= 0 ? (currentIndex + 1) % orientationOptions.length : 0;
     setSelectedOrientationId(orientationOptions[nextIndex].id);
   };
 
@@ -499,7 +508,11 @@ export default function VideoEditorScreen({ route, navigation }) {
     }
 
     const safeStart = clamp(startTime, 0, safeDurationSeconds);
-    const safeEnd = clamp(endTime, safeStart + MIN_GAP_SECONDS, safeDurationSeconds);
+    const safeEnd = clamp(
+      endTime,
+      safeStart + MIN_GAP_SECONDS,
+      safeDurationSeconds
+    );
     const durationSecondsValue = safeEnd - safeStart;
     if (durationSecondsValue <= 0) {
       Alert.alert(t('common.error'), t('videoEditor.invalidTrimMessage'));
@@ -510,7 +523,7 @@ export default function VideoEditorScreen({ route, navigation }) {
       uri: assetUri,
       duration: durationSecondsValue * 1000,
       fileName: asset?.fileName || assetUri.split('/').pop(),
-      mimeType: asset?.mimeType || 'video/mp4',
+      mimeType: resolveVideoMimeType(assetUri, asset?.mimeType || 'video/mp4'),
       orientation: selectedOrientationId,
       linePositionRatio: clampRatio(Number(linePositionRatio.toFixed(2))),
       originalDurationMs: Math.round(safeDurationSeconds * 1000),
@@ -529,8 +542,7 @@ export default function VideoEditorScreen({ route, navigation }) {
     ) {
       return null;
     }
-    const containerRatio =
-      videoContainerSize.width / videoContainerSize.height;
+    const containerRatio = videoContainerSize.width / videoContainerSize.height;
     if (videoAspectRatio >= containerRatio) {
       const width = videoContainerSize.width;
       const height = width / videoAspectRatio;
@@ -567,8 +579,10 @@ export default function VideoEditorScreen({ route, navigation }) {
           left: '50%',
           transform: [{ translateX: -24 }, { translateY: -24 }],
         };
-  const decrementIcon = lineStyle === 'vertical' ? 'chevron-left' : 'chevron-up';
-  const incrementIcon = lineStyle === 'vertical' ? 'chevron-right' : 'chevron-down';
+  const decrementIcon =
+    lineStyle === 'vertical' ? 'chevron-left' : 'chevron-up';
+  const incrementIcon =
+    lineStyle === 'vertical' ? 'chevron-right' : 'chevron-down';
   const scrubRatio = safeDurationSeconds
     ? clampRatio(currentTime / safeDurationSeconds)
     : 0;
@@ -721,7 +735,8 @@ export default function VideoEditorScreen({ route, navigation }) {
               style={styles.orientationIcon}
             />
             <Text style={styles.orientationButtonText}>
-              {orientationLabel}{orientationArrowText}
+              {orientationLabel}
+              {orientationArrowText}
             </Text>
           </TouchableOpacity>
         </View>

--- a/utils/videoMime.js
+++ b/utils/videoMime.js
@@ -1,0 +1,22 @@
+const VIDEO_MIME_BY_EXTENSION = {
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  m4v: 'video/x-m4v',
+  webm: 'video/webm',
+  mkv: 'video/x-matroska',
+  avi: 'video/x-msvideo',
+};
+
+export const resolveVideoMimeType = (uri, fallback = 'video/mp4') => {
+  const extension = String(uri || '')
+    .split('?')[0]
+    .split('.')
+    .pop()
+    ?.toLowerCase();
+
+  if (extension && VIDEO_MIME_BY_EXTENSION[extension]) {
+    return VIDEO_MIME_BY_EXTENSION[extension];
+  }
+
+  return fallback;
+};


### PR DESCRIPTION
### Motivation
- Corrigir inconsistências de MIME/metadata entre gravação, edição e upload que podem levar a falhas de processamento (ex.: vídeos pretos) ao normalizar o tipo de vídeo antes do envio.
- Tornar o fluxo de gravação mais robusto com limites razoáveis de duração e metadados derivados da URI real do arquivo.

### Description
- Adiciona utilitário `utils/videoMime.js` com `resolveVideoMimeType(uri, fallback)` para inferir `mimeType` a partir da extensão do arquivo (mp4, mov, m4v, webm, mkv, avi).
- Atualiza `screens/RecordVideoScreen.js` para usar `recordAsync({ maxDuration: 180 })` e enviar `mimeType` inferido por `resolveVideoMimeType(data.uri)` ao navegar para o editor.
- Atualiza `screens/VideoEditorScreen.js` para normalizar o `mimeType` do asset confirmado usando `resolveVideoMimeType(assetUri, asset?.mimeType || 'video/mp4')` antes de retornar para a Home.
- Atualiza `screens/HomeScreen.js` para aplicar `resolveVideoMimeType` ao construir/enriquecer assets vindos da galeria, da gravação ou da edição, mantendo metadados consistentes no pipeline de upload.

### Testing
- Executado `npx prettier --write screens/RecordVideoScreen.js screens/VideoEditorScreen.js screens/HomeScreen.js utils/videoMime.js` e a formatação foi aplicada com sucesso.
- Executado `npx prettier --check screens/RecordVideoScreen.js screens/VideoEditorScreen.js screens/HomeScreen.js utils/videoMime.js` e a verificação passou sem erros.
- Não foram executados testes de integração ou em device neste PR; alterações são focadas em metadados e formatação e devem ser validadas em device para confirmar que evita os casos de frames pretos no pipeline de processamento.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699397f80b7883218ac7d96b3ecf9dd0)